### PR TITLE
Implement Array.Copy()

### DIFF
--- a/Runtime/CoreLib.Script/Array.js
+++ b/Runtime/CoreLib.Script/Array.js
@@ -207,3 +207,23 @@ ss.arrayFill = function#? DEBUG ss$arrayFill##(dst, val, index, count) {
 			dst[index + count] = val;
 	}
 };
+
+ss.arrayCopy = function#? DEBUG ss$arrayCopy##(src, spos, dst, dpos, len) {
+	if (!ss.isValue(src) || !ss.isValue(dst))
+		throw new ss_NullReferenceException();
+
+	if (spos < 0 || dpos < 0 || len < 0)
+		throw new ss_ArgumentOutOfRangeException();
+
+	if (len > (src.length - spos) || len > (dst.length - dpos))
+		throw new ss_ArgumentException();
+
+	if (spos < dpos && src === dst) {
+		while (--len >= 0)
+			dst[dpos + len] = src[spos + len];
+	}
+	else {
+		for (var i = 0; i < len; i++)
+			dst[dpos + i] = src[spos + i];
+	}
+}

--- a/Runtime/CoreLib.Script/Array.js
+++ b/Runtime/CoreLib.Script/Array.js
@@ -209,9 +209,6 @@ ss.arrayFill = function#? DEBUG ss$arrayFill##(dst, val, index, count) {
 };
 
 ss.arrayCopy = function#? DEBUG ss$arrayCopy##(src, spos, dst, dpos, len) {
-	if (!ss.isValue(src) || !ss.isValue(dst))
-		throw new ss_NullReferenceException();
-
 	if (spos < 0 || dpos < 0 || len < 0)
 		throw new ss_ArgumentOutOfRangeException();
 

--- a/Runtime/CoreLib.TestScript/ArrayTests.cs
+++ b/Runtime/CoreLib.TestScript/ArrayTests.cs
@@ -394,5 +394,28 @@ namespace CoreLib.TestScript {
 			Assert.AreEqual(arr3, new string[] { "A", "B", "C", null });
 		}
 
+		[Test]
+		public void CopyWithDifferentArraysWorks() {
+			var arr1 = new[] { 1, 2, 3, 4 };
+			var arr2 = new[] { 9, 8, 7, 6 };
+			Array.Copy(arr1, arr2, 2);
+			Assert.AreEqual(arr2, new [] { 1, 2, 7, 6 });
+
+			var arr3 = new[] { 9, 8, 7, 6 };
+			Array.Copy(arr1, 3, arr3, 2, 1);
+			Assert.AreEqual(arr3, new [] { 9, 8, 4, 6 });
+		}
+
+		[Test]
+		public void CopyWithinArrayWorks() {
+			var arr1 = new[] { 1, 2, 3, 4 };
+			Array.Copy(arr1, 0, arr1, 1, 2);
+			Assert.AreEqual(arr1, new [] { 1, 1, 2, 4 });
+
+			var arr2 = new[] { 1, 2, 3, 4 };
+			Array.Copy(arr2, 2, arr2, 1, 2);
+			Assert.AreEqual(arr2, new [] { 1, 3, 4, 4 });
+		}
+
 	}
 }

--- a/Runtime/CoreLib/Array.cs
+++ b/Runtime/CoreLib/Array.cs
@@ -86,5 +86,13 @@ namespace System {
 		[InlineCode("{$System.Script}.arrayFill({dst}, {$System.Script}.getDefaultValue({T}), {index}, {count})")]
 		public static void Clear<T>(T[] dst, int index, int count) {
 		}
+
+		[InlineCode("{$System.Script}.arrayCopy({src}, {spos}, {dst}, {dpos}, {len})")]
+		public static void Copy(Array src, int spos, Array dst, int dpos, int len) {
+		}
+
+		[InlineCode("{$System.Script}.arrayCopy({src}, 0, {dst}, 0, {len})")]
+		public static void Copy(Array src, Array dst, int len) {
+		}
 	}
 }


### PR DESCRIPTION
There doesn't seem to be any standard ways of copying data between arrays in Javascript, and if you're doing any significant manipulation in .Net, System.Array.Copy() would be the natural choice.

Also note that as this is a static method, it can't be simulated with an extension method.