### PR TITLE
Add extra constructors for StringBuilder, ignoring any initial capacity ...

### DIFF
--- a/Runtime/CoreLib.TestScript/Text/StringBuilderTests.cs
+++ b/Runtime/CoreLib.TestScript/Text/StringBuilderTests.cs
@@ -26,10 +26,31 @@ namespace CoreLib.TestScript.Text {
 		}
 
 		[Test]
+		public void ConstructorWithCapacityWorks() {
+			var sb = new StringBuilder(55);
+			Assert.AreEqual(sb.ToString(), "", "Text");
+			Assert.AreEqual(sb.Length, 0, "Length");
+		}
+
+		[Test]
 		public void InitialTextConstructorWorks() {
 			var sb = new StringBuilder("some text");
 			Assert.AreEqual(sb.ToString(), "some text", "Text");
 			Assert.AreEqual(sb.Length, 9, "Length");
+		}
+
+		[Test]
+		public void InitialTextConstructorWithCapacityWorks() {
+			var sb = new StringBuilder("some text", 55);
+			Assert.AreEqual(sb.ToString(), "some text", "Text");
+			Assert.AreEqual(sb.Length, 9, "Length");
+		}
+
+		[Test]
+		public void SubstringConstructorWorks() {
+			var sb = new StringBuilder("some text", 5, 3, 55);
+			Assert.AreEqual(sb.ToString(), "tex", "Text");
+			Assert.AreEqual(sb.Length, 3, "Length");
 		}
 
 		[Test]

--- a/Runtime/CoreLib/Text/StringBuilder.cs
+++ b/Runtime/CoreLib/Text/StringBuilder.cs
@@ -21,12 +21,44 @@ namespace System.Text {
 		}
 
 		/// <summary>
+		/// Initializes a new instance of the <see cref="StringBuilder"/> class with the given capacity.
+		/// </summary>
+		/// <param name="capacity">Suggested starting size of the StringBuilder instance.</param>
+		[InlineCode("new {$System.Script}.StringBuilder()")] // Ignore suggested capacity
+		public StringBuilder(int capacity) {
+		}
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="StringBuilder"/> class.
 		/// </summary>
 		/// <param name="initialText">
 		/// The string that is used to initialize the value of the instance.
 		/// </param>
 		public StringBuilder(string initialText) {
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="StringBuilder"/> class.
+		/// </summary>
+		/// <param name="initialText">
+		/// The string that is used to initialize the value of the instance.
+		/// </param>
+		/// <param name="capacity">Suggested starting size of the StringBuilder instance.</param>
+		[InlineCode("new {$System.Script}.StringBuilder({initialText})")] // Ignore suggested capacity
+		public StringBuilder(string initialText, int capacity) {
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="StringBuilder"/> class with a substring.
+		/// </summary>
+		/// <param name="initialText">
+		/// The string that is used to initialize the value of the instance.
+		/// </param>
+		/// <param name="start">Starting position in initialText for substring.</param>
+		/// <param name="length">Length of substring.</param>
+		/// <param name="capacity">Suggested starting size of the StringBuilder instance.</param>
+		[InlineCode("new {$System.Script}.StringBuilder({initialText}.substr({start}, {length}))")]
+		public StringBuilder(string initialText, int start, int length, int capacity) {
 		}
 
 		/// <summary>


### PR DESCRIPTION
...values.

This change doesn't increase the library size but improves .Net compatibility a little.
I didn't add the two int constructor which specifies a maximum size as the implementation doesn't do the checks, and I doubt there is much need.