### PR TITLE
Ensure 'this' is the IComparer when the compare callback is called.

### DIFF
--- a/Runtime/CoreLib.Script/IComparer.js
+++ b/Runtime/CoreLib.Script/IComparer.js
@@ -6,3 +6,9 @@ var ss_IComparer = function#? DEBUG IComparer$##() { };
 ss_IComparer.__typeName = 'ss.IComparer';
 ss.IComparer = ss_IComparer;
 ss.initInterface(ss_IComparer, ss, { compare: null });
+
+ss.getComparer = function#? DEBUG ss$getComparer##(comparer) {
+	return function () {
+		return comparer.compare.apply(comparer, arguments);
+	};
+};

--- a/Runtime/CoreLib.Script/IComparer.js
+++ b/Runtime/CoreLib.Script/IComparer.js
@@ -6,9 +6,3 @@ var ss_IComparer = function#? DEBUG IComparer$##() { };
 ss_IComparer.__typeName = 'ss.IComparer';
 ss.IComparer = ss_IComparer;
 ss.initInterface(ss_IComparer, ss, { compare: null });
-
-ss.getComparer = function#? DEBUG ss$getComparer##(comparer) {
-	return function () {
-		return comparer.compare.apply(comparer, arguments);
-	};
-};

--- a/Runtime/CoreLib.TestScript/Collections/Generic/ListTests.cs
+++ b/Runtime/CoreLib.TestScript/Collections/Generic/ListTests.cs
@@ -360,6 +360,7 @@ namespace CoreLib.TestScript.Collections.Generic {
 
 		private class TestReverseComparer : IComparer<int> {
 			public int Compare(int x, int y) {
+				Assert.IsTrue(this is TestReverseComparer);
 				return x == y ? 0 : (x > y ? -1 : 1);
 			}
 		}

--- a/Runtime/CoreLib/Collections/Generic/List.cs
+++ b/Runtime/CoreLib/Collections/Generic/List.cs
@@ -217,7 +217,7 @@ namespace System.Collections.Generic {
 		public void Sort(Func<T, T, int> callback) {
 		}
 
-		[InlineCode("{this}.sort({comparer}.compare)")]
+		[InlineCode("{this}.sort({$System.Script}.getComparer({comparer}))")]
 		public void Sort(IComparer<T> comparer) {
 		}
 

--- a/Runtime/CoreLib/Collections/Generic/List.cs
+++ b/Runtime/CoreLib/Collections/Generic/List.cs
@@ -217,7 +217,7 @@ namespace System.Collections.Generic {
 		public void Sort(Func<T, T, int> callback) {
 		}
 
-		[InlineCode("{this}.sort({$System.Script}.getComparer({comparer}))")]
+		[InlineCode("{this}.sort({$System.Script}.mkdel({comparer}, {comparer}.compare))")]
 		public void Sort(IComparer<T> comparer) {
 		}
 


### PR DESCRIPTION
Some IComparers need to reference other data or instance methods, but sort() calls the compare callback with a different this value (window on Chrome), so wrap it in a closure.

There seemed to be a couple of similar routines already in mscorlib (ss.thisFix and ss.mkdel) but I couldn't see how to use them directly in this case. So I added a new ss.getComparer(), but I did wonder whether a more general version would be useful.

```
ss.wrapInstanceMethod = function(obj, meth) {
    return function() { return meth.apply(obj, arguments); };
};
```
Although this would result in a double reference to {comparer} in the sort case (and thus get lifted).
A less nice version that avoided that, using the method name might be:
```
ss.wrapInstanceMethod = function(obj, methName) {
    return function() { return obj[methName].apply(obj, arguments); };
};
```

By the way, I notice that arrays seem to inherit some Sort() methods without Array.cs declaring them. Presumably this is some magic inside the compiler mapping to List<T> ?  Or am I missing something obvious.  In .Net the Array.Sort() methods are static not instance methods (though in JS it is instance).