### PR TITLE
Add static JsConsole class to expose the various console methods available in Javascript

### DIFF
--- a/Runtime/CoreLib.Script/CoreLib.Script.csproj
+++ b/Runtime/CoreLib.Script/CoreLib.Script.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Comparer.js" />
+    <Content Include="JsConsole.js" />
     <Content Include="NotImplementedException.js" />
     <Content Include="DivideByZeroException.js" />
     <Content Include="RegExp.js" />

--- a/Runtime/CoreLib.Script/JsConsole.js
+++ b/Runtime/CoreLib.Script/JsConsole.js
@@ -1,0 +1,104 @@
+﻿// Polyfills for javascript console
+(function (noop, undef) {
+	var console = global.console;
+
+	// Takes an array of method console method names and assigns a polyfill implementation 
+	// to any which are not natively present
+	function polyfillMethods(methods, implementation) {
+		var i = methods.length,
+			m;
+
+		while (m = methods[--i]) {
+			if (typeof console[m] !== 'function') {
+				console[m] = implementation;
+			}
+		}
+	}
+
+	// Polyfill console.log for Opera <10.5
+	if (!console) {
+		if (global.opera && global.opera.postError) {
+			console = global.console = {};
+			console.log = function () {
+				// Make sure we join all args together as postError only accepts a single arg
+				global.opera.postError(Array.prototype.join.call(arguments, '\t'));
+			}
+		}
+	}
+
+	if (console && console.log) {
+		// All of the 'augmented logging' methods fall back to 'log'
+		polyfillMethods(['dir', 'info', 'warn', 'error'], console.log);
+
+		// Attempt to mimic trace by throwing and catching an error to get a stack trace
+		if (typeof console.trace !== 'function') {
+			console.trace = function() {
+				try {
+					throw new Error('console.trace()');
+				} catch (ex) {
+					if (ex && ex.stack) {
+						console.log(ex.stack);
+					} else {
+						console.log('Unable to capture stack trace.');
+					}
+				}
+			};
+		}
+
+		// We can't emulate group, so just make them noops
+		polyfillMethods(['group', 'groupCollapsed', 'groupEnd'], noop);
+
+		// Emulate count
+		var countCache = {},
+			countUndefinedCache;
+		if (typeof console.count !== 'function') {
+			console.count = function count(label) {
+				if (label === undef) {
+					if (typeof countUndefinedCache === 'number') {
+						console.log(': ' + (++countUndefinedCache));
+					} else {
+						console.log(': ' + (countUndefinedCache = 1));
+					}
+				} else {
+					if (typeof countCache[label] === 'number') {
+						console.log(label + ': ' + (++countCache[label]));
+					} else {
+						console.log(label + ': ' + (countCache[label] = 1));
+					}
+				}
+			}
+		}
+
+		// Emulate time/timeEnd (no sub-millisecond precision, but that is likely 
+		// not possible on a browser that lacks these methods to begin with)
+		var timeCache = {};
+		if (typeof console.time !== 'function') {
+			console.time = function time(label) {
+				// console.time ignores calls with no arguments/undefined
+				if (label !== undef) {
+					if (typeof timeCache[label] !== 'number') {
+						timeCache[label] = +new Date;
+					}
+				}
+			}
+
+			console.timeEnd = function timeEnd(label) {
+				if (label !== undef) {
+					if (typeof timeCache[label] === 'number') {
+						console.log(label + ': ' + (new Date - timeCache[label]) + 'ms');
+						delete timeCache[label];
+					}
+				}
+			}
+		}
+	} else {
+		// Make sure we have a console defined (not just a missing log method)
+		console = global.console = console || {};
+
+		// If we have no console log, just make all the methods noops to prevent runtime errors
+		polyfillMethods([
+			'log', 'dir', 'info', 'warn', 'error', 'trace',
+			'group', 'groupEnd', 'groupCollapsed', 'time', 'timeEnd', 'count'
+		], noop);
+	}
+})(function () { });

--- a/Runtime/CoreLib.Script/mscorlib.js
+++ b/Runtime/CoreLib.Script/mscorlib.js
@@ -368,6 +368,8 @@ if (typeof(window) == 'object') {
 
 #include "Guid.js"
 
+#include "JsConsole.js"
+
 if (global.ss) {
 	for (var n in ss) {
 		if (ss.hasOwnProperty(n))

--- a/Runtime/CoreLib.TestScript/CoreLib.TestScript.csproj
+++ b/Runtime/CoreLib.TestScript/CoreLib.TestScript.csproj
@@ -64,6 +64,7 @@
     <Compile Include="AppDomainTests.cs" />
     <Compile Include="ConvertTests.cs" />
     <Compile Include="CustomInitializationTests.cs" />
+    <Compile Include="JsConsoleTests.cs" />
     <Compile Include="UserDefinedStructTests.cs" />
     <Compile Include="EnvironmentTests.cs" />
     <Compile Include="Exceptions\NotImplementedExceptionTests.cs" />

--- a/Runtime/CoreLib.TestScript/JsConsoleTests.cs
+++ b/Runtime/CoreLib.TestScript/JsConsoleTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using QUnit;
+
+namespace CoreLib.TestScript
+{
+	[TestFixture]
+	public class JsConsoleTests
+	{
+		// Without mocking console (which would prevent catching some potential 
+		// errors in the polyfills etc.), we can only check here that the function 
+		// calls don't trigger errors when the Javascript they produce runs
+		[Test]
+		public void CanCallLogWithAnObject()
+		{
+			JsConsole.Log(new { a = "abc", b = 7.5 });
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallLogWithMultipleObjects()
+		{
+			JsConsole.Log(new { a = "abc", b = 7.5 }, DateTime.Now);
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallInfoWithAnObject()
+		{
+			JsConsole.Info(new { a = "abc", b = 7.5 });
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallInfoWithMultipleObjects()
+		{
+			JsConsole.Info(new { a = "abc", b = 7.5 }, 99);
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallWarnWithAnObject()
+		{
+			JsConsole.Warn(new { a = "abc", b = 7.5 });
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallWarnWithMultipleObjects()
+		{
+			JsConsole.Warn(new { a = "abc", b = 7.5 }, TimeSpan.Zero);
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallErrorWithAnObject()
+		{
+			JsConsole.Error(new { a = "abc", b = 7.5 });
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallErrorWithMultipleObjects()
+		{
+			JsConsole.Error(new { a = "abc", b = 7.5 }, TimeSpan.Zero);
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallDirWithAnObject()
+		{
+			JsConsole.Dir(new { a = "abc", b = 7.5 });
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallGroup()
+		{
+			JsConsole.Group();
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallGroupCollapsed()
+		{
+			JsConsole.GroupCollapsed();
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallGroupEnd()
+		{
+			JsConsole.GroupEnd();
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallCountWithoutALabel()
+		{
+			JsConsole.Count();
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallCountWithALabel()
+		{
+			JsConsole.Count("label");
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallTimeWithALabel()
+		{
+			JsConsole.Time("label");
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallTimeEndWithALabel()
+		{
+			JsConsole.TimeEnd("label");
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+
+		[Test]
+		public void CanCallTrace()
+		{
+			JsConsole.Trace();
+			Assert.OK(true, "Function call did not trigger an exception");
+		}
+	}
+}

--- a/Runtime/CoreLib/CoreLib.csproj
+++ b/Runtime/CoreLib/CoreLib.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Convert.cs" />
     <Compile Include="Base64FormattingOptions.cs" />
     <Compile Include="InternalScriptMetadata.cs" />
+    <Compile Include="JsConsole.cs" />
     <Compile Include="Predicate.cs" />
     <Compile Include="Environment.cs" />
     <Compile Include="NotImplementedException.cs" />

--- a/Runtime/CoreLib/JsConsole.cs
+++ b/Runtime/CoreLib/JsConsole.cs
@@ -1,0 +1,79 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace System
+{
+	[Imported]
+	[IgnoreNamespace]
+	[ScriptName("console")]
+	public static class JsConsole
+	{
+		[ScriptName("log")]
+		[ExpandParams]
+		public static void Log(params object[] data)
+		{
+		}
+
+		[ScriptName("info")]
+		[ExpandParams]
+		public static void Info(params object[] data)
+		{
+		}
+
+		[ScriptName("warn")]
+		[ExpandParams]
+		public static void Warn(params object[] data)
+		{
+		}
+
+		[ScriptName("error")]
+		[ExpandParams]
+		public static void Error(params object[] data)
+		{
+		}
+
+		[ScriptName("dir")]
+		public static void Dir(object data)
+		{
+		}
+
+		[ScriptName("group")]
+		public static void Group()
+		{
+		}
+
+		[ScriptName("groupCollapsed")]
+		public static void GroupCollapsed()
+		{
+		}
+
+		[ScriptName("groupEnd")]
+		public static void GroupEnd()
+		{
+		}
+
+		[ScriptName("count")]
+		public static void Count()
+		{
+		}
+
+		[ScriptName("count")]
+		public static void Count(string label)
+		{
+		}
+
+		[ScriptName("time")]
+		public static void Time(string label)
+		{
+		}
+
+		[ScriptName("timeEnd")]
+		public static void TimeEnd(string label)
+		{
+		}
+
+		[ScriptName("trace")]
+		public static void Trace()
+		{
+		}
+	}
+}


### PR DESCRIPTION
Addresses #379.

Not 100% thrilled with the tests and would be willing to improve if you have any preference on a different testing strategy, but this is a difficult thing to confirm it works as expected through unit testing without potentially missing other issues as a result.