### PR TITLE
Add dummy ComVisible and Guid attributes to System.Runtime.InteropServices.

### DIFF
--- a/Runtime/CoreLib/Runtime.cs
+++ b/Runtime/CoreLib/Runtime.cs
@@ -625,6 +625,42 @@ namespace System.Runtime.InteropServices {
 		public StructLayoutAttribute(short layoutKind) {}
 	}
 
+	/// <summary>
+	/// Dummy ComVisible attribute, used to prevent errors caused by the presence of a ComVisibleAttribute in the default AssemblyInfo.cs.
+	/// <para>Applying this attribute to an assembly has no effect on the generated code.</para>
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[NonScriptable]
+	public sealed class ComVisibleAttribute : Attribute
+	{
+		private readonly bool _val;
+		public bool Value { get { return _val; } }
+
+		public ComVisibleAttribute(bool visibility)
+		{
+			_val = visibility;
+		}
+	}
+
+	/// <summary>
+	/// Dummy Guid attribute, used to prevent errors caused by the presence of a GuidAttribute in the default AssemblyInfo.cs.
+	/// <para>Applying this attribute to an assembly has no effect on the generated code.</para>
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[NonScriptable]
+	public sealed class GuidAttribute : Attribute
+	{
+		private readonly string _val;
+		public string Value { get { return _val; } }
+
+		public GuidAttribute(string guid)
+		{
+			_val = guid;
+		}
+	}
+
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	[NonScriptable]
 	public enum CharSet {


### PR DESCRIPTION
Addresses #399.

Hopefully this is an acceptable fix, I just based the new attributes upon the ones already present in that namespace and documented them as being dummy implementations, there purely for the purpose of preventing the error detailed in the associated issue.