### PR TITLE
Add 'string with index' overloads for Char.IsDigit and Char.IsWhiteSpace

### DIFF
--- a/Runtime/CoreLib.TestScript/SimpleTypes/CharTests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/CharTests.cs
@@ -164,5 +164,29 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.IsTrue (char.IsWhiteSpace('\n'), "#2");
 			Assert.IsFalse(char.IsWhiteSpace('A'),  "#3");
 		}
+
+		[Test]
+		public void IsDigitWithStringAndIndexWorks()
+		{
+			Assert.IsTrue(char.IsDigit("abc0def", 3), "#1");
+			Assert.IsTrue(char.IsDigit("1", 0), "#2");
+			Assert.IsTrue(char.IsDigit("abcdef5", 6), "#3");
+			Assert.IsTrue(char.IsDigit("9abcdef", 0), "#4");
+			Assert.IsFalse(char.IsDigit(".012345", 0), "#5");
+			Assert.IsFalse(char.IsDigit("012345.", 6), "#6");
+			Assert.IsFalse(char.IsDigit("012.345", 3), "#7");
+		}
+
+		[Test]
+		public void IsWhiteSpaceWithStringAndIndexWorks()
+		{
+			Assert.IsTrue(char.IsWhiteSpace("abc def", 3), "#1");
+			Assert.IsTrue(char.IsWhiteSpace("\t", 0), "#2");
+			Assert.IsTrue(char.IsWhiteSpace("abcdef\r", 6), "#3");
+			Assert.IsTrue(char.IsWhiteSpace("\nabcdef", 0), "#4");
+			Assert.IsFalse(char.IsWhiteSpace(".\r\n     ", 0), "#5");
+			Assert.IsFalse(char.IsWhiteSpace("\r\n    .", 6), "#6");
+			Assert.IsFalse(char.IsWhiteSpace("\r  .\n  ", 3), "#7");
+		}
 	}
 }

--- a/Runtime/CoreLib/Char.cs
+++ b/Runtime/CoreLib/Char.cs
@@ -108,5 +108,17 @@ namespace System {
 		public static bool IsWhiteSpace(char ch) {
 			return false;
 		}
+
+		[InlineCode("/[0-9]/.test({s}[{index}])")]
+		public static bool IsDigit(string s, int index)
+		{
+			return false;
+		}
+
+		[InlineCode("/\\s/.test({s}[{index}])")]
+		public static bool IsWhiteSpace(string s, int index)
+		{
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
I believe this addresses #383, by providing the missing overloads for these methods.

Though the lack of a description on the issue makes it difficult to tell whether these were the methods believed to be missing or if they were requesting the addition of (non-standard) instance methods for checking if a char is a digit or white space.